### PR TITLE
Python: Minor changes to Record to support old test cases

### DIFF
--- a/python/pyiceberg/manifest.py
+++ b/python/pyiceberg/manifest.py
@@ -16,6 +16,7 @@
 # under the License.
 from enum import Enum
 from typing import (
+    Any,
     Dict,
     Iterator,
     List,
@@ -74,7 +75,7 @@ class FileFormat(str, Enum):
         return f"FileFormat.{self.name}"
 
 
-DATA_FILE_SCHEMA = StructType(
+DATA_FILE_TYPE = StructType(
     NestedField(
         field_id=134,
         name="content",
@@ -176,13 +177,16 @@ class DataFile(Record):
     sort_order_id: Optional[int]
     spec_id: Optional[int]
 
+    def __init__(self, *data: Any, **named_data: Any) -> None:
+        super().__init__(*data, **{"struct": DATA_FILE_TYPE, **named_data})
+
 
 MANIFEST_ENTRY_SCHEMA = Schema(
     NestedField(0, "status", IntegerType(), required=True),
     NestedField(1, "snapshot_id", LongType(), required=False),
     NestedField(3, "sequence_number", LongType(), required=False),
     NestedField(4, "file_sequence_number", LongType(), required=False),
-    NestedField(2, "data_file", DATA_FILE_SCHEMA, required=False),
+    NestedField(2, "data_file", DATA_FILE_TYPE, required=False),
 )
 
 
@@ -192,6 +196,9 @@ class ManifestEntry(Record):
     sequence_number: Optional[int]
     file_sequence_number: Optional[int]
     data_file: DataFile
+
+    def __init__(self, *data: Any, **named_data: Any) -> None:
+        super().__init__(*data, **{"struct": MANIFEST_ENTRY_SCHEMA.as_struct(), **named_data})
 
 
 PARTITION_FIELD_SUMMARY_TYPE = StructType(
@@ -207,6 +214,9 @@ class PartitionFieldSummary(Record):
     contains_nan: Optional[bool]
     lower_bound: Optional[bytes]
     upper_bound: Optional[bytes]
+
+    def __init__(self, *data: Any, **named_data: Any) -> None:
+        super().__init__(*data, **{"struct": PARTITION_FIELD_SUMMARY_TYPE, **named_data})
 
 
 MANIFEST_FILE_SCHEMA: Schema = Schema(
@@ -244,6 +254,9 @@ class ManifestFile(Record):
     deleted_rows_count: Optional[int]
     partitions: Optional[List[PartitionFieldSummary]]
     key_metadata: Optional[bytes]
+
+    def __init__(self, *data: Any, **named_data: Any) -> None:
+        super().__init__(*data, **{"struct": MANIFEST_FILE_SCHEMA.as_struct(), **named_data})
 
     def fetch_manifest_entry(self, io: FileIO) -> List[ManifestEntry]:
         file = io.new_input(self.manifest_path)

--- a/python/tests/avro/test_reader.py
+++ b/python/tests/avro/test_reader.py
@@ -371,13 +371,13 @@ def test_read_struct_exception_handling() -> None:
     mis = MemoryInputStream(b"\x18")
     decoder = BinaryDecoder(mis)
 
-    def raise_err(struct: StructType):
+    def raise_err(struct: StructType) -> None:
         raise TypeError("boom")
 
     struct = StructType(NestedField(1, "id", IntegerType(), required=True))
     # You can also pass in an arbitrary function that returns a struct
 
     with pytest.raises(ValueError) as exc_info:
-        _ = StructReader(((0, IntegerReader()),), raise_err, struct).read(decoder)  # pylint: disable=unnecessary-lambda
+        _ = StructReader(((0, IntegerReader()),), raise_err, struct).read(decoder)  # type: ignore
 
     assert "Unable to initialize struct:" in str(exc_info.value)

--- a/python/tests/expressions/test_evaluator.py
+++ b/python/tests/expressions/test_evaluator.py
@@ -70,79 +70,79 @@ def _record_float(id: float, f: float) -> Record:  # pylint: disable=redefined-b
 
 def test_true() -> None:
     evaluate = expression_evaluator(SIMPLE_SCHEMA, AlwaysTrue(), case_sensitive=True)
-    assert evaluate(_record_simple(1, "a"))
+    assert evaluate(Record(1, "a"))
 
 
 def test_false() -> None:
     evaluate = expression_evaluator(SIMPLE_SCHEMA, AlwaysFalse(), case_sensitive=True)
-    assert not evaluate(_record_simple(1, "a"))
+    assert not evaluate(Record(1, "a"))
 
 
 def test_less_than() -> None:
     evaluate = expression_evaluator(SIMPLE_SCHEMA, LessThan("id", 3), case_sensitive=True)
-    assert evaluate(_record_simple(2, "a"))
-    assert not evaluate(_record_simple(3, "a"))
+    assert evaluate(Record(2, "a"))
+    assert not evaluate(Record(3, "a"))
 
 
 def test_less_than_or_equal() -> None:
     evaluate = expression_evaluator(SIMPLE_SCHEMA, LessThanOrEqual("id", 3), case_sensitive=True)
-    assert evaluate(_record_simple(1, "a"))
-    assert evaluate(_record_simple(3, "a"))
-    assert not evaluate(_record_simple(4, "a"))
+    assert evaluate(Record(1, "a"))
+    assert evaluate(Record(3, "a"))
+    assert not evaluate(Record(4, "a"))
 
 
 def test_greater_than() -> None:
     evaluate = expression_evaluator(SIMPLE_SCHEMA, GreaterThan("id", 3), case_sensitive=True)
-    assert not evaluate(_record_simple(1, "a"))
-    assert not evaluate(_record_simple(3, "a"))
-    assert evaluate(_record_simple(4, "a"))
+    assert not evaluate(Record(1, "a"))
+    assert not evaluate(Record(3, "a"))
+    assert evaluate(Record(4, "a"))
 
 
 def test_greater_than_or_equal() -> None:
     evaluate = expression_evaluator(SIMPLE_SCHEMA, GreaterThanOrEqual("id", 3), case_sensitive=True)
-    assert not evaluate(_record_simple(2, "a"))
-    assert evaluate(_record_simple(3, "a"))
-    assert evaluate(_record_simple(4, "a"))
+    assert not evaluate(Record(2, "a"))
+    assert evaluate(Record(3, "a"))
+    assert evaluate(Record(4, "a"))
 
 
 def test_equal_to() -> None:
     evaluate = expression_evaluator(SIMPLE_SCHEMA, EqualTo("id", 3), case_sensitive=True)
-    assert not evaluate(_record_simple(2, "a"))
-    assert evaluate(_record_simple(3, "a"))
-    assert not evaluate(_record_simple(4, "a"))
+    assert not evaluate(Record(2, "a"))
+    assert evaluate(Record(3, "a"))
+    assert not evaluate(Record(4, "a"))
 
 
 def test_not_equal_to() -> None:
     evaluate = expression_evaluator(SIMPLE_SCHEMA, NotEqualTo("id", 3), case_sensitive=True)
-    assert evaluate(_record_simple(2, "a"))
-    assert not evaluate(_record_simple(3, "a"))
-    assert evaluate(_record_simple(4, "a"))
+    assert evaluate(Record(2, "a"))
+    assert not evaluate(Record(3, "a"))
+    assert evaluate(Record(4, "a"))
 
 
 def test_in() -> None:
     evaluate = expression_evaluator(SIMPLE_SCHEMA, In("id", [1, 2, 3]), case_sensitive=True)
-    assert evaluate(_record_simple(2, "a"))
-    assert evaluate(_record_simple(3, "a"))
-    assert not evaluate(_record_simple(4, "a"))
+    assert evaluate(Record(2, "a"))
+    assert evaluate(Record(3, "a"))
+    assert not evaluate(Record(4, "a"))
 
 
 def test_not_in() -> None:
     evaluate = expression_evaluator(SIMPLE_SCHEMA, NotIn("id", [1, 2, 3]), case_sensitive=True)
-    assert not evaluate(_record_simple(2, "a"))
-    assert not evaluate(_record_simple(3, "a"))
-    assert evaluate(_record_simple(4, "a"))
+    assert not evaluate(Record(2, "a"))
+    assert not evaluate(Record(3, "a"))
+    assert evaluate(Record(4, "a"))
 
 
 def test_is_null() -> None:
     evaluate = expression_evaluator(SIMPLE_SCHEMA, IsNull("data"), case_sensitive=True)
-    assert not evaluate(_record_simple(2, "a"))
-    assert evaluate(_record_simple(3, None))
+    assert not evaluate(Record(2, "a"))
+    assert evaluate(Record(3, None))
 
 
 def test_not_null() -> None:
     evaluate = expression_evaluator(SIMPLE_SCHEMA, NotNull("data"), case_sensitive=True)
-    assert evaluate(_record_simple(2, "a"))
-    assert not evaluate(_record_simple(3, None))
+    assert evaluate(Record(2, "a"))
+    assert not evaluate(Record(3, None))
 
 
 def test_is_nan() -> None:
@@ -161,19 +161,19 @@ def test_not_nan() -> None:
 
 def test_not() -> None:
     evaluate = expression_evaluator(SIMPLE_SCHEMA, Not(LessThan("id", 3)), case_sensitive=True)
-    assert not evaluate(_record_simple(2, "a"))
-    assert evaluate(_record_simple(3, "a"))
+    assert not evaluate(Record(2, "a"))
+    assert evaluate(Record(3, "a"))
 
 
 def test_and() -> None:
     evaluate = expression_evaluator(SIMPLE_SCHEMA, And(LessThan("id", 3), GreaterThan("id", 1)), case_sensitive=True)
-    assert not evaluate(_record_simple(1, "a"))
-    assert evaluate(_record_simple(2, "a"))
-    assert not evaluate(_record_simple(3, "a"))
+    assert not evaluate(Record(1, "a"))
+    assert evaluate(Record(2, "a"))
+    assert not evaluate(Record(3, "a"))
 
 
 def test_or() -> None:
     evaluate = expression_evaluator(SIMPLE_SCHEMA, Or(LessThan("id", 2), GreaterThan("id", 2)), case_sensitive=True)
-    assert evaluate(_record_simple(1, "a"))
-    assert not evaluate(_record_simple(2, "a"))
-    assert evaluate(_record_simple(3, "a"))
+    assert evaluate(Record(1, "a"))
+    assert not evaluate(Record(2, "a"))
+    assert evaluate(Record(3, "a"))

--- a/python/tests/expressions/test_visitors.py
+++ b/python/tests/expressions/test_visitors.py
@@ -16,12 +16,7 @@
 # under the License.
 # pylint:disable=redefined-outer-name
 
-from typing import (
-    Any,
-    List,
-    Optional,
-    Set,
-)
+from typing import Any, List, Set
 
 import pytest
 
@@ -74,12 +69,7 @@ from pyiceberg.expressions.visitors import (
     visit,
     visit_bound_predicate,
 )
-from pyiceberg.manifest import (
-    MANIFEST_FILE_SCHEMA,
-    PARTITION_FIELD_SUMMARY_TYPE,
-    ManifestFile,
-    PartitionFieldSummary,
-)
+from pyiceberg.manifest import ManifestFile, PartitionFieldSummary
 from pyiceberg.schema import Accessor, Schema
 from pyiceberg.types import (
     DoubleType,
@@ -797,9 +787,7 @@ def _to_byte_buffer(field_type: IcebergType, val: Any) -> bytes:
 
 def _to_manifest_file(*partitions: PartitionFieldSummary) -> ManifestFile:
     """Helper to create a ManifestFile"""
-    r = ManifestFile(struct=MANIFEST_FILE_SCHEMA.as_struct())
-    r[13] = partitions
-    return r
+    return ManifestFile(manifest_path="", manifest_length=0, partition_spec_id=0, partitions=partitions)
 
 
 INT_MIN_VALUE = 30
@@ -838,94 +826,83 @@ def manifest_no_stats() -> ManifestFile:
 
 @pytest.fixture
 def manifest() -> ManifestFile:
-    def _PartitionFieldSummary(
-        contains_null: bool, contains_nan: Optional[bool], lower_bound: Optional[bytes], upper_bound: Optional[bytes]
-    ) -> PartitionFieldSummary:
-        """Helper to create a PartitionFieldSummary"""
-        r = PartitionFieldSummary(struct=PARTITION_FIELD_SUMMARY_TYPE)
-        r[0] = contains_null
-        r[1] = contains_nan
-        r[2] = lower_bound
-        r[3] = upper_bound
-        return r
-
     return _to_manifest_file(
         # id
-        _PartitionFieldSummary(
+        PartitionFieldSummary(
             contains_null=False,
             contains_nan=None,
             lower_bound=INT_MIN,
             upper_bound=INT_MAX,
         ),
         # all_nulls_missing_nan
-        _PartitionFieldSummary(
+        PartitionFieldSummary(
             contains_null=True,
             contains_nan=None,
             lower_bound=None,
             upper_bound=None,
         ),
         # some_nulls
-        _PartitionFieldSummary(
+        PartitionFieldSummary(
             contains_null=True,
             contains_nan=None,
             lower_bound=STRING_MIN,
             upper_bound=STRING_MAX,
         ),
         # no_nulls
-        _PartitionFieldSummary(
+        PartitionFieldSummary(
             contains_null=False,
             contains_nan=None,
             lower_bound=STRING_MIN,
             upper_bound=STRING_MAX,
         ),
         # float
-        _PartitionFieldSummary(
+        PartitionFieldSummary(
             contains_null=True,
             contains_nan=None,
             lower_bound=_to_byte_buffer(FloatType(), 0.0),
             upper_bound=_to_byte_buffer(FloatType(), 20.0),
         ),
         # all_nulls_double
-        _PartitionFieldSummary(contains_null=True, contains_nan=None, lower_bound=None, upper_bound=None),
+        PartitionFieldSummary(contains_null=True, contains_nan=None, lower_bound=None, upper_bound=None),
         # all_nulls_no_nans
-        _PartitionFieldSummary(
+        PartitionFieldSummary(
             contains_null=True,
             contains_nan=False,
             lower_bound=None,
             upper_bound=None,
         ),
         # all_nans
-        _PartitionFieldSummary(
+        PartitionFieldSummary(
             contains_null=False,
             contains_nan=True,
             lower_bound=None,
             upper_bound=None,
         ),
         # both_nan_and_null
-        _PartitionFieldSummary(
+        PartitionFieldSummary(
             contains_null=True,
             contains_nan=True,
             lower_bound=None,
             upper_bound=None,
         ),
         # no_nan_or_null
-        _PartitionFieldSummary(
+        PartitionFieldSummary(
             contains_null=False,
             contains_nan=False,
             lower_bound=_to_byte_buffer(FloatType(), 0.0),
             upper_bound=_to_byte_buffer(FloatType(), 20.0),
         ),
         # all_nulls_missing_nan_float
-        _PartitionFieldSummary(contains_null=True, contains_nan=None, lower_bound=None, upper_bound=None),
+        PartitionFieldSummary(contains_null=True, contains_nan=None, lower_bound=None, upper_bound=None),
         # all_same_value_or_null
-        _PartitionFieldSummary(
+        PartitionFieldSummary(
             contains_null=True,
             contains_nan=None,
             lower_bound=STRING_MIN,
             upper_bound=STRING_MIN,
         ),
         # no_nulls_same_value_a
-        _PartitionFieldSummary(
+        PartitionFieldSummary(
             contains_null=False,
             contains_nan=None,
             lower_bound=STRING_MIN,

--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -59,7 +59,7 @@ from pyiceberg.io.pyarrow import (
     project_table,
     schema_to_pyarrow,
 )
-from pyiceberg.manifest import DATA_FILE_SCHEMA, DataFile
+from pyiceberg.manifest import DataFile, FileFormat
 from pyiceberg.partitioning import PartitionSpec
 from pyiceberg.schema import Schema, visit
 from pyiceberg.table import FileScanTask, Table
@@ -746,14 +746,13 @@ def file_map(schema_map: Schema, tmpdir: str) -> str:
 def project(
     schema: Schema, files: List[str], expr: Optional[BooleanExpression] = None, table_schema: Optional[Schema] = None
 ) -> pa.Table:
-    def _construct_data_file(file: str) -> DataFile:
-        data_file = DataFile(struct=DATA_FILE_SCHEMA)
-        data_file[1] = file  # file_path
-        data_file[5] = 0  # file_size_in_bytes
-        return data_file
-
     return project_table(
-        [FileScanTask(_construct_data_file(file)) for file in files],
+        [
+            FileScanTask(
+                DataFile(file_path=file, file_format=FileFormat.PARQUET, partition={}, record_count=3, file_size_in_bytes=3)
+            )
+            for file in files
+        ],
         Table(
             ("namespace", "table"),
             metadata=TableMetadataV2(

--- a/python/tests/test_typedef.py
+++ b/python/tests/test_typedef.py
@@ -47,10 +47,7 @@ def test_keydefaultdict() -> None:
 
 
 def test_record_repr(table_schema_simple: Schema) -> None:
-    r = Record(struct=table_schema_simple.as_struct())
-    r[0] = "vo"
-    r[1] = 1
-    r[2] = True
+    r = Record("vo", 1, True, struct=table_schema_simple.as_struct())
     assert repr(r) == "Record[foo='vo', bar=1, baz=True]"
 
 
@@ -76,3 +73,17 @@ def test_named_record() -> None:
 def test_record_positional_args() -> None:
     r = Record(1, "a", True)
     assert repr(r) == "Record[field1=1, field2='a', field3=True]"
+
+
+def test_record_named_args() -> None:
+    r = Record(foo=1, bar="a", baz=True)
+
+    assert r.foo == 1  # type: ignore
+    assert r.bar == "a"  # type: ignore
+    assert r.baz is True  # type: ignore
+
+    assert r[0] == 1
+    assert r[1] == "a"
+    assert r[2] is True
+
+    assert repr(r) == "Record[foo=1, bar='a', baz=True]"


### PR DESCRIPTION
This updates `Record` so that the old test cases are valid. Record now supports instantiation using positional data, named data, and optionally passing a struct type for both.

For ManifestFile and other classes, the schema is defaulted in the constructor.